### PR TITLE
chore: delete deprecated templates

### DIFF
--- a/cms/src/taccsite_custom/texascale-org/templates/article.freeform.html
+++ b/cms/src/taccsite_custom/texascale-org/templates/article.freeform.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/article.freeform.html" %}

--- a/cms/src/taccsite_custom/texascale-org/templates/article.html
+++ b/cms/src/taccsite_custom/texascale-org/templates/article.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/article.html" %}

--- a/cms/src/taccsite_custom/texascale-org/templates/article.image-map.html
+++ b/cms/src/taccsite_custom/texascale-org/templates/article.image-map.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/article.image-map.html" %}

--- a/cms/src/taccsite_custom/texascale-org/templates/article.sidebar-right.html
+++ b/cms/src/taccsite_custom/texascale-org/templates/article.sidebar-right.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/article.sidebar-right.html" %}

--- a/cms/src/taccsite_custom/texascale-org/templates/article.visual.html
+++ b/cms/src/taccsite_custom/texascale-org/templates/article.visual.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/article.visual.html" %}

--- a/cms/src/taccsite_custom/texascale-org/templates/category.html
+++ b/cms/src/taccsite_custom/texascale-org/templates/category.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/category.html" %}

--- a/cms/src/taccsite_custom/texascale-org/templates/fullwidth.html
+++ b/cms/src/taccsite_custom/texascale-org/templates/fullwidth.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/fullwidth.html" %}


### PR DESCRIPTION
## Overview

Delete deprecated templates.

## Testing

1. Log in to server.
2. List templates and pages each is used on:

    ```sh
    sudo docker exec -it portal_cms sh -c "python manage.py list_page_templates"
    ```

3. Verify **zero** `texascale-org` templates are used.
4. Verify I delete **all** `texascale-org` templates.
5. Verify I do **not** delete `texascale_cms` templates.