### PR TITLE
fix: header font should not change with new cms

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/site.header.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/site.header.css
@@ -1,0 +1,3 @@
+.s-header {
+  font-size:  16px;font-weight: normal;
+}

--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/site.header.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/site.header.css
@@ -1,5 +1,5 @@
 .s-header {
   font-size:  16px;
-  font-weight: var(--light);
+  font-weight: normal;
   font-family: var(--global-font-family--sans--cms);
 }

--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/site.header.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/site.header.css
@@ -1,4 +1,5 @@
 .s-header {
   font-size:  16px;
   font-weight: var(--light);
+  font-family: var(--global-font-family--sans--cms);
 }

--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/site.header.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/site.header.css
@@ -1,3 +1,4 @@
 .s-header {
-  font-size:  16px;font-weight: normal;
+  font-size:  16px;
+  font-weight: var(--light);
 }

--- a/cms/src/taccsite_custom/texascale_cms/templates/fullwidth.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/fullwidth.html
@@ -9,6 +9,7 @@
   {{ block.super }}
 
   <link rel="stylesheet" href="{% static 'texascale_cms/css/site.css' %}">
+  <link rel="stylesheet" href="{% static 'texascale_cms/css/site.header.css' %}">
 {% endblock assets_custom %}
 
 {# To remove container and breadcrumbs #}


### PR DESCRIPTION
## Overview

Upgrading CMS changed the header font. It's gone unnoticed or unmentioned on other sites. I fix for Texascale, because we scrutinize its design heavily.

## Changes

- changed header font

## Testing

1. Deploy on staging.
2. Compare to production.
3. Font should be similar.

> [!NOTE]
> Not identical, because old CMS used wrong Benton Sans font, which has long since been remedied, but never deployed to production.

## UI

Before (new CMS, no Fix):
<img width="960" height="177" alt="2 updated" src="https://github.com/user-attachments/assets/a827300e-c147-4725-9500-f44f5b994c26" />

Expected (old CMS):
<img width="960" height="177" alt="1 original" src="https://github.com/user-attachments/assets/4f871af1-96bd-439d-83f3-22f7236c7a6f" />

After (new CMS, and Fix):
<img width="960" height="178" alt="3 fixed C" src="https://github.com/user-attachments/assets/54b5860d-3e4a-40ec-9291-619c42d0498a" />