### PR TITLE
chore: blog config cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ Learn about [Texascale Stylesheets](./cms/src/taccsite_custom/texascale_cms/stat
 [Core CMS Template]: https://github.com/TACC/Core-CMS-Template
 [Core Portal Deployments]: https://github.com/TACC/Core-Portal-Deployments
 
-[core-cms-template-setup]: https://github.com/TACC/Core-CMS-Template/blob/v0.3.0/docs/create-project.md#set-up-project
-[core-cms-template-start]: https://github.com/TACC/Core-CMS-Template/blob/v0.3.0/docs/start-project.md#start-project
-[core-cms-template-docs]: https://github.com/TACC/Core-CMS-Template/blob/v0.3.0/docs/README.md#tacc-custom-cms
+[core-cms-template-setup]: https://github.com/TACC/Core-CMS-Template/blob/v0.3.1/docs/create-project.md#set-up-project
+[core-cms-template-start]: https://github.com/TACC/Core-CMS-Template/blob/v0.3.1/docs/start-project.md#start-project
+[core-cms-template-docs]: https://github.com/TACC/Core-CMS-Template/blob/v0.3.1/docs/README.md#tacc-custom-cms

--- a/cms/src/taccsite_cms/urls_custom.py
+++ b/cms/src/taccsite_cms/urls_custom.py
@@ -1,4 +1,4 @@
-from django.urls import include, re_path
+from django.urls import re_path, include
 
 custom_urls = [
     # To support `taggit_autosuggest` (from `djangocms-blog`)

--- a/cms/src/taccsite_custom/texascale_cms/urls.py
+++ b/cms/src/taccsite_custom/texascale_cms/urls.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-from taccsite_cms.urls import *
-
-from django.urls import include, re_path
-
-urlpatterns += [
-    # Support `taggit_autosuggest` (from `djangocms-blog`)
-    re_path(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
-]


### PR DESCRIPTION
## Overview

Clean up blog config.

## Related

- https://github.com/TACC/Core-Portal-Deployments/commit/3b4467d

## Changes

- swap import order
    <sup>Just to match Core.</sup>
- remove redundant `urls` config
    <sup>Because [`urls_custom.py`](https://github.com/TACC/Texascale-CMS/blob/v0.2.1/cms/src/taccsite_cms/urls_custom.py#L3-L6) will be used.</sup>