### PR TITLE
feat: enable breadcrumbs (i.e. Standard template)

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/templates/base.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/base.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% load cms_tags static %}
+
+{% block assets_font %}
+  <link rel="stylesheet" href="https://use.typekit.net/xnr7bof.css">
+{% endblock assets_font %}
+
+{% block assets_custom %}
+  {{ block.super }}
+
+  <link rel="stylesheet" href="{% static 'texascale_cms/css/site.css' %}">
+  <link rel="stylesheet" href="{% static 'texascale_cms/css/site.header.css' %}">
+{% endblock assets_custom %}

--- a/cms/src/taccsite_custom/texascale_cms/templates/fullwidth.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/fullwidth.html
@@ -1,16 +1,5 @@
-{% extends "base.html" %}
-{% load cms_tags static %}
-
-{% block assets_font %}
-  <link rel="stylesheet" href="https://use.typekit.net/xnr7bof.css">
-{% endblock assets_font %}
-
-{% block assets_custom %}
-  {{ block.super }}
-
-  <link rel="stylesheet" href="{% static 'texascale_cms/css/site.css' %}">
-  <link rel="stylesheet" href="{% static 'texascale_cms/css/site.header.css' %}">
-{% endblock assets_custom %}
+{% extends "./base.html" %}
+{% load cms_tags %}
 
 {# To remove container and breadcrumbs #}
 {% block content %}

--- a/cms/src/taccsite_custom/texascale_cms/templates/standard.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/standard.html
@@ -1,0 +1,1 @@
+{% extends "./base.html" %}


### PR DESCRIPTION
## Overview

Allow a page to have breadcrumbs.

## Changes

- added templates:
    - `base.html`
    - `standard.html`
- moved custom assets and custom font:
    - from `fullwidth.html`
    - to `base.html`

## Testing

1. To `settings_custom.py` in `CMS_TEMPLATES`, prepend:
    ```py
        ('texascale_cms/templates/standard.html', 'Standard'),
    ```
2. Create a root-level page.
3. Set Template to "Standard".
4. Verify breadcrumbs are present.
5. Set Template to "that Inherit the template of nearest ancestor."
6. Verify breadcrumbs are present.

## UI

| standard | inherit | remote |
| - | - | - |
| <img width="960" height="465" alt="inherit" src="https://github.com/user-attachments/assets/1df4e3d3-ae23-4fee-a2a9-8efbdfeac253" /> | <img width="960" height="465" alt="standard" src="https://github.com/user-attachments/assets/496d9330-8681-4ff3-8f38-92cc6ec2926c" /> | <img width="960" height="465" alt="remote" src="https://github.com/user-attachments/assets/447ff456-a244-4ad3-a8d7-2a3a801148df" /> |