### PR TITLE
refactor: forget docker_repo.var

### DIFF
--- a/cms/Makefile
+++ b/cms/Makefile
@@ -1,4 +1,4 @@
-DOCKERHUB_REPO := $(shell cat ./docker_repo.var)
+DOCKERHUB_REPO := taccwma/texascale-cms
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest

--- a/cms/bin/setup-cms.sh
+++ b/cms/bin/setup-cms.sh
@@ -103,25 +103,6 @@ for file in settings_custom settings_local secrets; do
     fi
 done
 
-# Create expected .var files if they don't exist (if enabled)
-if [ "$CREATE_VAR_FILES" = true ]; then
-    echo -e "${INF}Setting up .var files...${RST}"
-    if [ ! -f "needs_demo.var" ]; then
-        echo "false" > needs_demo.var
-        echo -e "  ${POS}Created needs_demo.var${RST}"
-    else
-        echo -e "  ${INF}needs_demo.var already exists${RST}"
-    fi
-    if [ ! -f "docker_repo.var" ]; then
-        echo "core-cms" > docker_repo.var
-        echo -e "  ${POS}Created docker_repo.var${RST}"
-    else
-        echo -e "  ${INF}docker_repo.var already exists${RST}"
-    fi
-else
-    echo -e "${INF}Skipping .var file creation (disabled)${RST}"
-fi
-
 # Build and start Docker containers (from project root)
 echo -e "${INF}Building and starting Docker containers...${RST}"
 cd "$PROJECT_ROOT"


### PR DESCRIPTION
## Overview

Forget `docker_repo.var`. This CMS is alone in this repo, so explicitly name its Docker Hub repo.

> [!NOTE]
> Developers may delete `docker_hub.var`.

## Related

- mimics https://github.com/TACC/Core-CMS/pull/966
- similar to https://github.com/TACC/Core-CMS-Template/pull/10
- similar to https://github.com/TACC/APCD-CMS/pull/18

## Changes

- **deletes** `docker_repo.var` reference and requirement

## Testing

**Meh.**

The only affected commands are `make build-full`, `make publish`, `make publish-latest`, but no one runs those, because we use GitHub Actions instead.