### PR TITLE
feat: bootstrap tabs, image thumbnail in tab

### DIFF
--- a/cms/Dockerfile
+++ b/cms/Dockerfile
@@ -2,5 +2,6 @@ FROM taccwma/core-cms:latest
 
 WORKDIR /code
 
+COPY /src/texascale_custom /code/texascale_custom
 COPY /src/taccsite_custom /code/taccsite_custom
 COPY /src/taccsite_cms /code/taccsite_cms

--- a/cms/docker-compose.dev.yml
+++ b/cms/docker-compose.dev.yml
@@ -8,6 +8,7 @@ services:
     hostname: core_cms
     volumes:
       - ./src/taccsite_custom:/code/taccsite_custom
+      - ./src/texascale_custom:/code/texascale_custom
       - ./src/taccsite_cms/custom_app_settings.py:/code/taccsite_cms/custom_app_settings.py
       - ./src/taccsite_cms/urls_custom.py:/code/taccsite_cms/urls_custom.py
       - ./src/taccsite_cms/settings_custom.py:/code/taccsite_cms/settings_custom.py

--- a/cms/src/taccsite_cms/custom_app_settings.py
+++ b/cms/src/taccsite_cms/custom_app_settings.py
@@ -1,0 +1,17 @@
+CUSTOM_APPS = [
+
+    # TEXASCALE_CUSTOM
+    # !!!: Independent app to customize site cuz texascale_cms did not let me
+    'texascale_custom.apps.TexascaleCustomConfig',
+
+    # DJANGOCMS_BLOG
+    'parler',
+    'taggit',
+    'taggit_autosuggest',
+    'sortedm2m',
+    'djangocms_blog',
+
+]
+
+CUSTOM_MIDDLEWARE = []
+STATICFILES_DIRS = ()

--- a/cms/src/texascale_custom/__init__.py
+++ b/cms/src/texascale_custom/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'texascale_custom.apps.TexascaleCustomConfig'

--- a/cms/src/texascale_custom/apps.py
+++ b/cms/src/texascale_custom/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+
+class TexascaleCustomConfig(AppConfig):
+    name = 'texascale_custom'
+    label = 'texascale_custom'
+    verbose_name = 'TACC CMS (Texascale Customizations)'
+
+    def ready(self):
+        from .djangocms_bootstrap4_tabs.extend import extendBootstrap4TabsPlugin
+
+        extendBootstrap4TabsPlugin()

--- a/cms/src/texascale_custom/djangocms_bootstrap4_tabs/extend.py
+++ b/cms/src/texascale_custom/djangocms_bootstrap4_tabs/extend.py
@@ -1,0 +1,180 @@
+import logging
+
+logger = logging.getLogger(f"portal.{__name__}")
+
+def extendBootstrap4TabsPlugin():
+    from django import forms
+    from django.utils.translation import gettext_lazy as _
+
+    from cms.plugin_pool import plugin_pool
+
+    from filer.models import Image
+
+    def validate_tab_image(instance):
+        """Validates that the tab image exists and is valid"""
+        from django.core.exceptions import ValidationError
+
+        errors = {}
+
+        if hasattr(instance, 'attributes') and instance.attributes:
+            image_id = instance.attributes.get('data-tab-image-id')
+            if image_id:
+                try:
+                    Image.objects.get(id=image_id)
+                except Image.DoesNotExist:
+                    errors['tab_image'] = _(
+                        f"Selected image (ID: {image_id}) no longer exists in the file manager. "
+                        "Please select a new image or remove the image reference."
+                    )
+                except (ValueError, TypeError) as e:
+                    errors['tab_image'] = _(
+                        f"Please select a valid image or remove the image reference."
+                        f"ERROR: {str(e)}"
+                    )
+
+        if errors:
+            raise ValidationError(errors)
+
+    def filter_attributes_str(attributes):
+        """
+        Create HTML attributes string excluding internal data.
+        """
+        if not attributes:
+            return ""
+
+        filtered_attributes = {
+            k: v for k, v in attributes.items()
+            if k not in ['data-tab-image-id']
+        }
+
+        if not filtered_attributes:
+            return ""
+
+        attr_parts = []
+        for key, value in filtered_attributes.items():
+            if value is not None and value != '':
+                attr_parts.append(f'{key}="{value}"')
+
+        return ' ' + ' '.join(attr_parts) if attr_parts else ""
+
+
+    # djangocms_bootstrap4
+    from djangocms_bootstrap4.contrib.bootstrap4_tabs.cms_plugins import (
+        Bootstrap4TabItemPlugin as OriginalBootstrap4TabItemPlugin
+    )
+    from djangocms_bootstrap4.contrib.bootstrap4_tabs.models import (
+        Bootstrap4TabItem as OriginalBootstrap4TabItem
+    )
+
+    class Bootstrap4TabItemForm(OriginalBootstrap4TabItemPlugin.form):
+        tab_image = forms.ModelChoiceField(
+            queryset=Image.objects.all(),
+            required=False,
+            label=_('Tab Image/Thumbnail'),
+            help_text=_('Optional image to display in the tab title for slideshow navigation')
+        )
+
+    class Bootstrap4TabItemModel(OriginalBootstrap4TabItem):
+        class Meta:
+            proxy = True
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            if not hasattr(self, 'attributes') or self.attributes is None:
+                self.attributes = {}
+
+        def _initialize_tab_image(self):
+            """Initialize the tab_image property from attributes"""
+            if hasattr(self, 'attributes') and self.attributes:
+                image_id = self.attributes.get('data-tab-image-id')
+                if image_id:
+                    self.tab_image = Image.objects.filter(id=image_id).first()
+
+        def clean(self):
+            cleaned_data = super().clean()
+
+            form_data = getattr(self, '_form_data', {})
+            if 'tab_image' in form_data:
+                tab_image = form_data['tab_image']
+                if tab_image:
+                    self.attributes['data-tab-image-id'] = str(tab_image.id)
+                elif 'data-tab-image-id' in self.attributes:
+                    logger.debug(
+                        "Cleaning up orphaned tab image reference: %s",
+                        self.attributes['data-tab-image-id']
+                    )
+                    del self.attributes['data-tab-image-id']
+
+            validate_tab_image(self)
+
+            if not hasattr(self, '_tab_image_initial_set'):
+                self._initialize_tab_image()
+                self._tab_image_initial_set = True
+
+            return cleaned_data
+
+        @property
+        def tab_image(self):
+            if not hasattr(self, '_tab_image'):
+                self._tab_image = None
+                image_id = self.attributes.get('data-tab-image-id')
+                if image_id:
+                    try:
+                        self._tab_image = Image.objects.get(id=image_id)
+                    except (Image.DoesNotExist, ValueError):
+                        pass
+            return self._tab_image
+
+        @tab_image.setter
+        def tab_image(self, value):
+            self._tab_image = value
+            if value:
+                self.attributes['data-tab-image-id'] = str(value.id)
+            elif 'data-tab-image-id' in self.attributes:
+                del self.attributes['data-tab-image-id']
+
+    class Bootstrap4TabItemPlugin(OriginalBootstrap4TabItemPlugin):
+        model = Bootstrap4TabItemModel
+        form = Bootstrap4TabItemForm
+        
+        # Add the tab_image field to the fieldsets
+        fieldsets = [
+            (None, {
+                'fields': (
+                    'tab_title',
+                    'tag_type',
+                    'tab_image',
+                )
+            }),
+            (None, {
+                'fields': (
+                    'attributes',
+                )
+            })
+        ]
+
+        def get_form(self, request, obj=None, **kwargs):
+            form = super().get_form(request, obj, **kwargs)
+            return form
+
+        def render(self, context, instance, placeholder):
+            context = super().render(context, instance, placeholder)
+
+            tab_image = None
+            if instance.attributes and 'data-tab-image-id' in instance.attributes:
+                try:
+                    tab_image = Image.objects.get(id=instance.attributes['data-tab-image-id'])
+                except (Image.DoesNotExist, ValueError):
+                    del instance.attributes['data-tab-image-id']
+                    instance.save()
+
+            context.update({
+                'tab_image': tab_image,
+                'has_tab_image': tab_image is not None,
+                'filtered_attributes_str': filter_attributes_str(instance.attributes or {})
+            })
+
+            return context
+
+    plugin_pool.unregister_plugin(OriginalBootstrap4TabItemPlugin)
+    plugin_pool.register_plugin(Bootstrap4TabItemPlugin)


### PR DESCRIPTION
## Overview

Extend Bootstrap Tabs to support an image thumbnail inside one of the tabs.

## Status

- [x] Create extension
- [x] Find way to load extension
    <sup>(cuz taccsite_custom dirs are not proper apps)</sup>
- [ ] Fix image field
- [ ] Add templating

> [!IMPORTANT]
> **Do not try to fix `taccsite_custom` app support yet!** That can be done later, and this extension ported over. It's just an import and a function call. Don't get distracted with `taccsite_custom`.

## Related

…

## Changes

…

## Testing

1. Create Bootstrap Tabs instance.
2. Create/Edit a Bootstrap Tab Item.
3. ✅ Find "Tab Image" field.
4. ❌ Choose an image.
5. Save.
6. Verify Image renders inside Tab.

## UI

<img width="960" height="475" alt="progress" src="https://github.com/user-attachments/assets/bf8d288d-f48f-4f7b-bad8-c721f8a8495a" />