### PR TITLE
refactor: commit INSTALLED_APPS for blog

### DIFF
--- a/cms/src/taccsite_cms/custom_app_settings.py
+++ b/cms/src/taccsite_cms/custom_app_settings.py
@@ -1,12 +1,4 @@
-# import os
-
-# BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
 CUSTOM_APPS = [
-
-    # TEXASCALE_CUSTOM
-    # !!!: Independent app to customize site cuz texascale_cms did not let me
-    'texascale_custom.apps.TexascaleCustomConfig',
 
     # DJANGOCMS_BLOG
     'parler',
@@ -18,7 +10,4 @@ CUSTOM_APPS = [
 ]
 
 CUSTOM_MIDDLEWARE = []
-
-# STATICFILES_DIRS = (
-#     os.path.join(BASE_DIR, 'texascale_custom', 'static'),
-# )
+STATICFILES_DIRS = ()

--- a/cms/src/taccsite_cms/custom_app_settings.py
+++ b/cms/src/taccsite_cms/custom_app_settings.py
@@ -1,0 +1,24 @@
+# import os
+
+# BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+CUSTOM_APPS = [
+
+    # TEXASCALE_CUSTOM
+    # !!!: Independent app to customize site cuz texascale_cms did not let me
+    'texascale_custom.apps.TexascaleCustomConfig',
+
+    # DJANGOCMS_BLOG
+    'parler',
+    'taggit',
+    'taggit_autosuggest',
+    'sortedm2m',
+    'djangocms_blog',
+
+]
+
+CUSTOM_MIDDLEWARE = []
+
+# STATICFILES_DIRS = (
+#     os.path.join(BASE_DIR, 'texascale_custom', 'static'),
+# )


### PR DESCRIPTION
## Overview

Save the custom items for `INSTALLED_APPS` (which blog needs) via `custom_app_settings.py` instead of in [Core-Portal-Deployments](https://github.com/TACC/Core-Portal-Deployments), because other non-sensitive settings are here, like `urls_custom.py`

## Related

N/A

## Changes

- **adds** `custom_app_settings.py`

## Testing

1. Deployed.
2. [Blog page](https://pprd.texascale.tacc.utexas.edu/testing/news/?edit) still loads.
3. [Blog admin](https://pprd.texascale.tacc.utexas.edu/admin/djangocms_blog/) is still present.

## UI

| page | admin |
| - | - |
| <img width="960" height="470" alt="page" src="https://github.com/user-attachments/assets/9e2f970c-a995-485b-8be9-9a7c6f26185a" /> | <img width="960" height="470" alt="admin" src="https://github.com/user-attachments/assets/4cb8877f-fd95-4423-b22f-96676ce5c4de" /> |