### PR TITLE
test(cms): Core-CMS#975 does not break templates

### DIFF
--- a/cms/Dockerfile
+++ b/cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:latest
+FROM taccwma/core-cms:feat-allow-custom-sites-to-overwrite-app-templates
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Test https://github.com/TACC/Core-CMS/pull/975 does not break current template usage.

## Related

- requires https://github.com/TACC/Core-CMS/pull/975

## Changes

- **adds** `custom_app_settings.py`

## Testing

1. Deployed.
2. Opened "legacy"-style pages with Full-Width and Category templates.
3. Opened "modern"-style pages with Full-Width and Category templates.
4. No change.

## UI

Skipped.