### PR TITLE
fix: should not scroll to tab content

### DIFF
--- a/cms/src/taccsite_custom/taccsite_bootstrap4_tabs/static/taccsite_bootstrap4_tabs/js/tabs.js
+++ b/cms/src/taccsite_custom/taccsite_bootstrap4_tabs/static/taccsite_bootstrap4_tabs/js/tabs.js
@@ -1,15 +1,8 @@
-let _ignoreNextHashChange = false;
-
-/** To custom handle default tab links such that tab click changes URL */
+/** To make tab click change URL */
 function handleDefaultTabLinks() {
     document.querySelectorAll('[id^="tab-label"]').forEach(tabLink => {
-        tabLink.addEventListener('click', (event) => {
-            // To prevent handleTabsFromURL from reacting to the hashchange that a genuine user click will cause. Only set the flag for trusted (user) clicks, so programmatic activations aren't treated the same.
-            if (event && event.isTrusted) {
-                _ignoreNextHashChange = true;
-            }
-
-            $(tabLink).tab('show');
+        tabLink.addEventListener('click', () => {
+            history.replaceState(null, null, tabLink.hash);
         });
     });
 }
@@ -33,12 +26,6 @@ function handleExtraTabLinks() {
 /** To show correct tab when URL has/changes hash */
 function handleTabsFromURL() {
     function showFromHash() {
-        if (_ignoreNextHashChange) {
-            _ignoreNextHashChange = false;
-            console.info('Ignoring hash change');
-            return;
-        }
-
         const id = (window.location.hash || '').replace(/^#tab-/, '');
         if (!id) return;
 
@@ -52,7 +39,7 @@ function handleTabsFromURL() {
     window.addEventListener('hashchange', showFromHash);
 }
 
-/** To call all handling */
+/** To enable all handling */
 function handleTabLinks() {
     handleDefaultTabLinks();
     handleExtraTabLinks();

--- a/cms/src/taccsite_custom/templates/djangocms_bootstrap4/tabs/default/tabs.html
+++ b/cms/src/taccsite_custom/templates/djangocms_bootstrap4/tabs/default/tabs.html
@@ -7,7 +7,7 @@
 {% endaddtoblock %}
 {# /TACC #}
 {# TACC (support manual nav links): #}
-{# TACC (so tab click changes URL): #}
+{# TACC (so tabs respect URL hash): #}
 {% addtoblock "js" %}
 <script src="{% static 'taccsite_bootstrap4_tabs/js/tabs.js' %}" type="module"></script>
 {% endaddtoblock %}
@@ -23,9 +23,7 @@
                 <a href="#tab-{{ forloop.counter }}"
                     class="nav-link{% if instance.tab_index == forloop.counter %} active{% endif %}"
                     id="tab-label-{{ forloop.counter }}"
-                    {# TACC (so tab click changes URL): #}
-                    {# data-toggle="tab" #}
-                    {# /TACC #}
+                    data-toggle="tab"
                     aria-controls="tab-{{ forloop.counter }}"
                     aria-selected="{% if instance.tab_index == forloop.counter %}true{% else %}false{% endif %}"
                     role="tab">


### PR DESCRIPTION
## Overview

Triggering tab —

- click
- URL hash change
- custom link

— should **not** scroll to tab.

## Related

- fixes #22

## Changes

- **changes** programmatic hash change to `history.push`
- **changes** default link handling to be extended not overwritten

## Testing

0. Make browser window **not** tall.
1. Repeat #22.
2. Verify page does not scroll.

## UI

Skipped.
