### PR TITLE
feat: quiet css build

### DIFF
--- a/cms/bin/build-css.js
+++ b/cms/bin/build-css.js
@@ -6,8 +6,16 @@ const ROOT = __dirname + '/../';
 const BUILD_ID = process.env.BUILD_ID || process.env.npm_package_version;
 const ASSET_PATH = ROOT + 'src/taccsite_custom/texascale_cms/static/texascale_cms/';
 
+const argv = process.argv.slice(2);
+
+const supportedVerboseFlags = [
+  '--quiet', '--silent', '--no-verbose'
+];
+const hasVerboseFlag = argv.some(flag => supportedVerboseFlags.includes(flag));
+const verbose = (!hasVerboseFlag);
+
 const options = {
-  verbose: true,
+  verbose,
   fileExt: '.css',
   buildId: BUILD_ID,
   // If custom configuration is desired, then create and pass this file


### PR DESCRIPTION
## Overview

Allow CSS to be built quietly.

## Changes

- **adds** support for CLI flags when running `build-css.js`

## Testing

1. `npm run build`
2. Verbose output.
3. `npm run build -- --quiet`
4. **Not** verbose output.
3. `npm run build -- --silent`
4. **Not** verbose output.
3. `npm run build -- --not-verbose`
4. **Not** verbose output.

## UI

Skipped.