### PR TITLE
feat: 2025 styles (colors)

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/_imports/settings/color.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/_imports/settings/color.css
@@ -1,0 +1,8 @@
+:root {
+  --tx-blue:  #003049;    /* Prussian Blue */
+  --tx-white: #FCFDF3;    /* Ivory */
+  --tx-orange: #BF5700;   /* Texas Orange */
+  --tx-yellow: #FCBF49;   /* Xanthous */
+  --tx-beige: #EAE2B7;    /* Vanilla */
+  --tx-black: #231F1E;    /* Raisin Black */
+}

--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/cms.2025.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/cms.2025.css
@@ -1,0 +1,1 @@
+/*! @tacc/texascale-cms 1.1.0 | MIT | texascale.org */:root{--tx-blue:#003049;--tx-white:#fcfdf3;--tx-orange:#bf5700;--tx-yellow:#fcbf49;--tx-beige:#eae2b7;--tx-black:#231f1e}

--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/cms.2025.postcss
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/cms.2025.postcss
@@ -1,0 +1,4 @@
+/* Import only. Use ITCSS: */
+/* https://tacc-main.atlassian.net/wiki/x/QQhv */
+
+@import url("./_imports/settings/color.css");

--- a/cms/src/taccsite_custom/texascale_cms/templates/base.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/base.html
@@ -19,5 +19,7 @@
   <link rel="stylesheet" href="https://use.typekit.net/xnr7bof.css">
   <link rel="stylesheet" href="{% static 'texascale_cms/css/site.css' %}">
   <link rel="stylesheet" href="{% static 'texascale_cms/css/site.header.css' %}">
+  {% else %}
+  <link rel="stylesheet" href="{% static 'texascale_cms/css/cms.2025.css' %}">
   {% endif %}
 {% endblock assets_custom %}


### PR DESCRIPTION
## Overview

Basic 2025 styles. (Colors.)

## Changes

- **adds** `texascale_cms/css/imports/settings/color.css`
- **adds** `texascale_cms/css/cms.2025.postcss`
- **loads** `texascale_cms/css/cms.2025.css`

## Testing

1. set `TEXASCALE_PUBLISHED_YEAR = 2025` in `settings_*.py`
2. `make start` (or `make setup`)
3. `npm run watch`
4. open site
5. check Network tab
6. find `cms.2025.css`
7. verify it has styles (colors)

## UI

<img width="960" height="470" alt="Screenshot 2025-08-14 at 19 40 02" src="https://github.com/user-attachments/assets/e2b97edc-04de-45e6-af86-c496581a9dbd" />