### PR TITLE
feat: core-cms v4.36.3

### DIFF
--- a/cms/Dockerfile
+++ b/cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:feat-allow-custom-sites-to-overwrite-app-templates
+FROM taccwma/core-cms:v4.36.3
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Set Core-CMS to published version (a pre-release) [v4.36.3](https://github.com/TACC/Core-CMS/releases/tag/v4.36.3).

## Related

- to use https://github.com/TACC/Core-CMS/pull/975
- for https://github.com/TACC/Texascale-CMS/pull/22
- tested via
    - https://github.com/TACC/Texascale-CMS/pull/24
    - https://github.com/TACC/Core-Portal-Deployments/pull/100