### PR TITLE
fix: overactive snippet to make future link text selectable

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/templates/snippets/js-let-use-select-text-inside-link-blocks.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/snippets/js-let-use-select-text-inside-link-blocks.html
@@ -1,4 +1,4 @@
 <script
     type = "module"
-    src = "https://cdn.jsdelivr.net/gh/TACC/Core-Styles@b3f163b/src/lib/_utils/js/auto-make-link-text-selectable.js"
->/* https://github.com/TACC/Core-Styles/pull/540 */</script>
+    src = "https://cdn.jsdelivr.net/gh/TACC/Core-Styles@eea94ec9/src/lib/_utils/js/auto-make-link-text-selectable.js"
+>/* https://github.com/TACC/Core-Styles/pull/541 */</script>


### PR DESCRIPTION
## Overview

Update CDN path to get fix for utility script that makes future card link text selectable.

## Related

- requires https://github.com/TACC/Core-Styles/pull/541
- continues #32
- fixes #21

## Changes

Update Core-Styles to get fix for script loaded via snippet.

## Testing & UI

**Skipped.** But like https://github.com/TACC/Core-Styles/pull/541 on Texascale.