### PR TITLE
fix: modern free-form article should not force tag

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/templates/article.freeform.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/article.freeform.html
@@ -2,7 +2,11 @@
 {% load cms_tags is_design %}
 
 {% block content %}
-  <article>{% placeholder "content" %}</article>
+  {% is_design_legacy as is_legacy %}
+
+  {% if is_legacy %}<article>{% endif %}
+  {% placeholder "content" %}
+  {% if is_legacy %}</article>{% endif %}
 {% endblock content %}
 
 {% block js %}


### PR DESCRIPTION
## Overview

Do not force `<article>` around new free-form articles.
