### PR TITLE
perf(legacy): let browser connect to kepler font/css vendor sooner

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/templates/base.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/base.html
@@ -16,6 +16,7 @@
 
   {% is_design_legacy as is_legacy %}
   {% if is_legacy %}
+  <link rel="preconnect" href="https://use.typekit.net/">
   <link rel="stylesheet" href="https://use.typekit.net/xnr7bof.css">
   <link rel="stylesheet" href="{% static 'texascale_cms/css/legacy/site.css' %}">
   <link rel="stylesheet" href="{% static 'texascale_cms/css/legacy/site.header.css' %}">


### PR DESCRIPTION
## Overview / Changes

In Legacy styles, use `<link rel="preconnect">` to:
> […] hint to browsers that the user is likely to need resources from the target resource's origin, and therefore the browser can likely improve the user experience by preemptively initiating a connection to that origin. Preconnecting speeds up future loads from a given origin by preemptively performing part or all of the handshake […]
> — [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preconnect)

## Related

Also done for 2025 styles in db02f33.

## Testing & UI

> [!IMPORTANT]
> Untested.