### PR TITLE
feat: hide PluginImporter

### DIFF
--- a/cms/src/taccsite_custom/static/djangocms_transfer/css/hide_plugin.css
+++ b/cms/src/taccsite_custom/static/djangocms_transfer/css/hide_plugin.css
@@ -1,0 +1,4 @@
+.js-disabled {
+    pointer-events: none;
+    opacity: 0.5;
+}

--- a/cms/src/taccsite_custom/static/djangocms_transfer/js/hide_plugin.js
+++ b/cms/src/taccsite_custom/static/djangocms_transfer/js/hide_plugin.js
@@ -1,0 +1,24 @@
+/** To hide PluginImporter plugin from list for admins editing page */
+
+const itemQuery = '[href="PluginImporter"]';
+const cmsUiWrapper = document.getElementById('cms-top');
+
+function disableItem(item) {
+    item.classList.add('js-disabled');
+}
+
+// Hide current items
+const utilPluginMenuItem = cmsUiWrapper.querySelector(itemQuery);
+if (utilPluginMenuItem) disableItem(utilPluginMenuItem);
+
+// Hide future items
+const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+            const isElement = node.nodeType === Node.ELEMENT_NODE;
+            const item = (isElement) && node.querySelector(itemQuery);
+            if (item) disableItem(item);
+        });
+    });
+});
+observer.observe(cmsUiWrapper, { childList: true, subtree: true });

--- a/cms/src/taccsite_custom/texascale_cms/templates/base.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/base.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load cms_tags static is_design %}
+{% load cms_tags static is_design sekizai_tags %}
 
 {% block assets %}
   {% is_design_legacy as is_legacy %}
@@ -23,4 +23,11 @@
   {% else %}
   <link rel="stylesheet" href="{% static 'texascale_cms/css/2025/cms.css' %}">
   {% endif %}
+
+  {# To disable "ImporterPlugin" on plugin list #}
+  {# IDEA: Suggest this for TACC/Core-CMS #}
+  {% addtoblock "js" %}
+    <link rel="stylesheet" href="{% static 'djangocms_transfer/css/hide_plugin.css' %}">
+    <script type="module" src="{% static 'djangocms_transfer/js/hide_plugin.js' %}"></script>
+  {% endaddtoblock %}
 {% endblock assets_custom %}


### PR DESCRIPTION
## Overview

Hide "PluginImporter" in plugin list.

## Related

- supports #___

## Changes

- adds and loads a style and a script

## Testing

0. Be logged in as admin.
1. Edit any page.
2. Open list to add plugin.
3. Search "Import".
4. Verify "PluginImporter" is:
    - disabled
    - greyed out

## UI

<img width="960" height="470" alt="Screenshot 2025-09-02 at 20 38 15" src="https://github.com/user-attachments/assets/39507d42-9a8a-4af8-8903-87b267568409" />
