### PR TITLE
feat: "global-assets" placeholder

### DIFF
--- a/cms/src/taccsite_custom/static/cms/css/3.11.4/reorder_placeholders.css
+++ b/cms/src/taccsite_custom/static/cms/css/3.11.4/reorder_placeholders.css
@@ -1,0 +1,15 @@
+/* To allow movement of placeholders */
+div.cms .cms-structure-content {
+    display: flex;
+    flex-direction: column;
+}
+div.cms .cms-structure-content .cms-dragarea {
+    /* To prevent layout changes after this became a flex item */
+    margin-inline: unset;
+    margin-bottom: unset; /* */
+}
+
+/* To move "Global …" placeholder to bottom */
+div.cms .cms-structure-content .cms-dragarea:has([title^="Global"]) {
+    order: 999;
+}

--- a/cms/src/taccsite_custom/texascale_cms/templates/base.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/base.html
@@ -38,8 +38,14 @@
 
   {# To offer "Global Assets" placeholder (not "Footer-Content") for Snippets #}
   {# IDEA: Suggest this for TACC/Core-CMS #}
+  {# WARNING: Does NOT load on http://...?structure standalone.
+              To load on that page, add the same thing in —
+              /cms/templates/cms/toolbar/toolbar_javascript.html
+              — plus all the content from the original —
+              https://github.com/django-cms/django-cms/blob/3.11.4/cms/templates/cms/toolbar/toolbar_javascript.html
+              — which must be copy/pasted cuz it offers no blocks #}
   {% addtoblock "css" %}
-    {# To move `global-assets` placeholder to bottom of Structure #}
+    {# To move placeholders around in Structure the panel #}
     <link rel="stylesheet" href="{% static 'cms/css/3.11.4/reorder_placeholders.css' %}">
   {% endaddtoblock %}
   {% static_placeholder "global-assets" %}

--- a/cms/src/taccsite_custom/texascale_cms/templates/base.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/base.html
@@ -38,14 +38,17 @@
 
   {# To offer "Global Assets" placeholder (not "Footer-Content") for Snippets #}
   {# IDEA: Suggest this for TACC/Core-CMS #}
-  {# WARNING: Does NOT load on http://...?structure standalone.
-              To load on that page, add the same thing in —
-              /cms/templates/cms/toolbar/toolbar_javascript.html
-              — plus all the content from the original —
-              https://github.com/django-cms/django-cms/blob/3.11.4/cms/templates/cms/toolbar/toolbar_javascript.html
-              — which must be copy/pasted cuz it offers no blocks #}
   {% addtoblock "css" %}
     {# To move placeholders around in Structure the panel #}
+    {% comment %}
+    WARNING: Does NOT load on http://...?structure standalone.
+
+    To load on that page, add the same thing in —
+    `/cms/templates/cms/toolbar/toolbar_javascript.html`
+    — plus all the content from the original —
+    https://github.com/django-cms/django-cms/blob/3.11.templates/cms/toolbar/toolbar_javascript.html
+    — which must be copy/pasted cuz it offers no blocks.
+    {% endcomment %}
     <link rel="stylesheet" href="{% static 'cms/css/3.11.4/reorder_placeholders.css' %}">
   {% endaddtoblock %}
   {% static_placeholder "global-assets" %}

--- a/cms/src/taccsite_custom/texascale_cms/templates/base.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/base.html
@@ -31,3 +31,16 @@
     <script type="module" src="{% static 'djangocms_transfer/js/hide_plugin.js' %}"></script>
   {% endaddtoblock %}
 {% endblock assets_custom %}
+
+<!-- Custom Assets (Delayed). -->
+{% block assets_custom_delayed %}
+  {{ block.super }}
+
+  {# To offer "Global Assets" placeholder (not "Footer-Content") for Snippets #}
+  {# IDEA: Suggest this for TACC/Core-CMS #}
+  {% addtoblock "css" %}
+    {# To move `global-assets` placeholder to bottom of Structure #}
+    <link rel="stylesheet" href="{% static 'cms/css/3.11.4/reorder_placeholders.css' %}">
+  {% endaddtoblock %}
+  {% static_placeholder "global-assets" %}
+{% endblock %}


### PR DESCRIPTION
## Overview

Add a "Global-Assets" placeholder.

## Related

- supported by #42

## Changes

- adds `{% static_placeholder "global-assets" %}`
- adds `reorder_placeholders.css` to move placeholder to bottom of editor's Structure list

## Testing

1. Add to `settings_custom.py`:
    ```py
    CMS_PLACEHOLDER_CONF = {
        'global-assets': {
            'plugins': ['SnippetPlugin'],
            'name': 'Global Assets (Styles & Scripts)',
        },
    }
    ```
2. Be logged in and edit page.
3. Open Structure panel.[^1]
4. ✅ Verify "Global Assets" placeholder is visible.
5. ✅ Verify "Global Assets" placeholder is at bottom.
6. Add plugin to "Global Assets".
7. ✅ Verify "Snippet" (and [PluginImporter](https://github.com/TACC/Texascale-CMS/pull/42)) is visible.
8. ✅ Add snippet. Save page. Refresh. Verify snippet is present on page.

[^1]: Such that it opens in a sidebar, not in a new window.

## UI

| 4 & 5 | 7 | 8 | 8 |
| - | - | - | - |
| <img width="960" height="470" alt="4 snippet loaded" src="https://github.com/user-attachments/assets/bae323df-ca28-4ffb-96a0-55477d80fb76" /> | <img width="960" height="470" alt="2 add snippet" src="https://github.com/user-attachments/assets/93db6a51-472e-4f03-a011-ef02f0b699a9" /> | <img width="960" height="470" alt="1 empty" src="https://github.com/user-attachments/assets/1ef89638-de2b-4cc6-a9de-e81dc00e100d" /> | <img width="960" height="470" alt="3 snippet added" src="https://github.com/user-attachments/assets/2e083a5c-176f-4bd5-86c7-447372413f86" /> |

## Notes

> [!WARNING]
> Reordering does **not** work if editor visits `?structure` directly i.e. in a new window e.g. https://texascale.org/featured-stories/?structure.