### PR TITLE
fix: published year is not 2025 yet

### DIFF
--- a/cms/src/taccsite_cms/settings_custom.py
+++ b/cms/src/taccsite_cms/settings_custom.py
@@ -6,8 +6,7 @@
 # TEXASCALE
 ########################
 
-TEXASCALE_PUBLISHED_YEAR = 2025
-
+TEXASCALE_PUBLISHED_YEAR = 2024
 
 ########################
 # DJANGO


### PR DESCRIPTION
## Overview

Do **not** set published year to 2025 (yet).

## Related

- fixes #44
- restore value from #13

## Changes

- revert `TEXASCALE_PUBLISHED_YEAR` value to match production

## Testing / UI

Skipped. Don't need/want to test. Already tested in #13.

## Notes

Feel free to set `TEXASCALE_PUBLISHED_YEAR = 2025` in `settings_local.py` for testing.