### PR TITLE
refactor: page_type_class not template_class nor html_page_class

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/templates/category.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/category.html
@@ -11,7 +11,4 @@
 {% endblock assets_custom %}
 
 {# Add class to the <html> #}
-{# SEE: TACC/Core-CMS before 2023-02-08@16:30 #}
-{% block template_class %}s-category-page{% endblock template_class %}
-{# SEE: TACC/Core-CMS after 2023-02-08@16:30 #}
-{% block html_page_class %}s-category-page{% endblock html_page_class %}
+{% block page_type_class %}s-category-page{% endblock page_type_class %}


### PR DESCRIPTION
## Overview

Use only `page_type_class`:
- **not** unsupported `template_class`
- **not** outdated `html_page_class`.

## Related

- some Core-CMS commit around 2023-02-08@16:30

## Changes

- **deleted** use of `template_class`
- **replaced** use of `html_page_class` with `page_type_class`

## Testing

1. Open category page.
2. Verify `s-category-page` is class of `<body>`.
3. Verify `s-category-page` is **not** class of `<html>`.

_Styles unaffected, because [styles only affect content within `<body>`](https://github.com/search?q=repo%3ATACC%2FTexascale-CMS%20%22.s-category-page%22&type=code)._

## UI

Skipped.

## Notes

Clients can use:
- **either** (manual) `page_type_class`
- **or** (automatic) `data-page-template`

Clients can use `html_page_class`, but I plan to deprecate it, because:
- `<body> ` offers `page_type_class`
- `<html>` can be selected via `:has(body[page_type_class="…"])`