### PR TITLE
fix: page_type_class ignores parent value

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/templates/article.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/article.html
@@ -28,4 +28,7 @@
 </article>
 {% endblock content %}
 
-{% block page_type_class %}s-article-page{% endblock page_type_class %}
+{% block page_type_class %}
+  {{ block.super }}
+  s-article-page
+{% endblock page_type_class %}

--- a/cms/src/taccsite_custom/texascale_cms/templates/category.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/category.html
@@ -11,4 +11,7 @@
 {% endblock assets_custom %}
 
 {# Add class to the <html> #}
-{% block page_type_class %}s-category-page{% endblock page_type_class %}
+{% block page_type_class %}
+  {{ block.super }}
+  s-category-page
+{% endblock page_type_class %}


### PR DESCRIPTION
## Overview

A template using `page_type_class` would hide pre-existing value from template it extends.

## Related

- to support upcoming change

## Changes

- **adds** `{{ block.super }}`

## Testing

1. Set `page_type_class` in `fullwidth.html`.
2. Load any article.
3. Verify class from step 1 is visible.
4. Verify class `s-article-page` is visible.

## UI

Skipped.

## Notes

No such usage exists yet to reveal this bug, but it is about to.