### PR TITLE
feat(css): trick to achieve 100vw minus scrollbar width

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/4_elements/roots.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/4_elements/roots.css
@@ -10,3 +10,10 @@ body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
+
+/* To support using `cqw` unit as "100vw – scrollbar width" */
+/* https://www.smashingmagazine.com/2023/12/new-css-viewport-units-not-solve-classic-scrollbar-problem/#avoiding-the-classic-scrollbar-problem */
+/* TODO: Consider moving to Core-CMS */
+body {
+	container-type: inline-size;
+}


### PR DESCRIPTION
## Overview

Allow UI developer a way to define width as "100% of viewport minus scrollbar width".

## Related

- almost used for #54

## Changes

- **adds** one style rule to `body`

## Testing

0. Be on a page with vertical scroll.
1. Set width of any element to `100cqw`.
2. Verify element is as wide as viewport.
3. Verify element does **not** cause _horizontal_ scrollbar.

## UI

**Skipped.** Tested in #54.

## Notes

Comes from [Smashing Magazine: Avoiding The Classic Scrollbar Problem](https://www.smashingmagazine.com/2023/12/new-css-viewport-units-not-solve-classic-scrollbar-problem/#avoiding-the-classic-scrollbar-problem).
