### PR TITLE
feat(css): .texascale-slide

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/templates/snippets/2025/2025-css-slide.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/snippets/2025/2025-css-slide.html
@@ -1,0 +1,45 @@
+{% load sekizai_tags %}
+{% addtoblock "css" %}
+{# FAQ: `data-design="2025" media="not all"` protects Legacy pages #}
+<style id="2025-css-slider" data-design="2025" media="not all">
+/* To style slides */
+.texascale-slide-tabs .nav-tabs {
+	display: none;
+}
+.texascale-slide {
+	background: var(--tacc-blue);
+	color: var(--tacc-white);
+}
+.texascale-slide :not(.tab-toggle, :has(.tab-toggle)) {
+	--tacc-black: #FCFDF3;
+	--tacc-white: #231F1E;
+}
+
+/* To style toggles */
+.texascale-slide .tab-toggle {
+	/* TODO: Consider adding to colors.css */
+	--texascale-glass: color(
+		from var(--tacc-white) srgb r g b / 0.6
+	);
+
+	border-color: transparent;
+	background-color: var(--texascale-glass);
+	background-image: url('https://texascale.org/static/texascale_cms/img/tab-toggle-arrow-black.svg');
+}
+
+/* To position tab toggles */
+.texascale-slide {
+	position: relative;
+}
+.texascale-slide .tab-toggle:first-child,
+.texascale-slide .tab-toggle:last-child {
+	--offset: 100px;
+
+	position: absolute;
+	top: 50%;
+	translate: 0 -50%;
+}
+.texascale-slide .tab-toggle:first-child { left: var(--offset); }
+.texascale-slide .tab-toggle:last-child { right: var(--offset); }
+</style>
+{% endaddtoblock %}


### PR DESCRIPTION
## Overview

Introduce `.texascale-slide` and `.texascale-slide-tabs`.

## Related

- 2025 Texascale Design

## Changes

- **adds** a snippet

## Testing

0. Open https://texascale.org/testing/2025/people-programs/mentorship-pays-it-forward/.
1. Scroll to bottom (just above footer).
2. Compare slide UI to [design](https://www.figma.com/design/JuEhoowQ5COCYJ8H8li3sz/TexasScale-WebSite?node-id=497-496&m=dev).
3. Test slide arrows.

## UI

…