### PR TITLE
refactor: move new vars to 2025 CMS CSS

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/1_settings/colors.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/1_settings/colors.css
@@ -1,10 +1,12 @@
-/* COLORS: Texascale */
+/* Texascale */
 :root {
 	--texascale-gold: #D0B786;
 	--texascale-bkgd: var(--global-color-background--app);
-	--texascale-kepler: kepler-std, serif;
+	--texascale-glass: color(
+		from var(--tacc-white) srgb r g b / 0.6
+	);
 }
-/* COLORS: TACC/Core v3 (early) */
+/* TACC/Core v3 (early) */
 :root {
 	--tacc-blue:  #003049;    /* Prussian Blue */
 	--tacc-white: #FCFDF3;    /* Ivory */

--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/1_settings/fonts.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/1_settings/fonts.css
@@ -1,0 +1,4 @@
+/* Texascale */
+:root {
+	--texascale-kepler: kepler-std, serif;
+}

--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/1_settings/spaces.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/1_settings/spaces.css
@@ -1,0 +1,5 @@
+/* Bootstrap 4 */
+/* TODO: Add to TACC/Core-Styles */
+:root {
+	--bs4-gutter-x: 15px;
+}

--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/cms.postcss
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/cms.postcss
@@ -2,6 +2,8 @@
 /* https://tacc-main.atlassian.net/wiki/x/QQhv */
 
 @import './1_settings/colors.css';
+@import './1_settings/spaces.css';
+@import './1_settings/fonts.css';
 
 @import './4_elements/roots.css';
 

--- a/cms/src/taccsite_custom/texascale_cms/templates/snippets/2025/2025-css-slide.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/snippets/2025/2025-css-slide.html
@@ -22,11 +22,6 @@
 
 /* To style toggles */
 .texascale-slide .tab-toggle {
-	/* TODO: Consider adding to colors.css */
-	--texascale-glass: color(
-		from var(--tacc-white) srgb r g b / 0.6
-	);
-
 	border-color: transparent;
 	background-color: var(--texascale-glass);
 	background-image: url('https://texascale.org/static/texascale_cms/img/tab-toggle-arrow-black.svg');
@@ -44,8 +39,6 @@
 }
 .texascale-slide .tab-toggle:first-child,
 .texascale-slide .tab-toggle:last-child {
-	--bs4-gutter-x: 15px;
-
 	--offset: calc(-1 * (
 		var(--size) - var(--bs4-gutter-x)
 	));


### PR DESCRIPTION
## Overview

Move CSS variables from slide snippet to `cms.css`.