### PR TITLE
feat: Core-CMS v4.36.5

### DIFF
--- a/cms/Dockerfile
+++ b/cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:v4.36.4
+FROM taccwma/core-cms:v4.36.5
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Update Core-CMS to latest pre-release, [v4.36.5](https://github.com/TACC/Core-CMS/releases/tag/v4.36.5). 
