### PR TITLE
fix: txsc slide tab toggle cause horz scroll

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/templates/snippets/2025/2025-css-slide.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/snippets/2025/2025-css-slide.html
@@ -10,6 +10,9 @@
 	background: var(--tacc-blue);
 	color: var(--tacc-white);
 }
+.texascale-slide:has(.tab-toggle) {
+	overflow: hidden; /* to avoid horz. scroll if toggles escape viewport */
+}
 .texascale-slide :not(.tab-toggle, :has(.tab-toggle)) {
 	--tacc-black: #FCFDF3;
 	--tacc-white: #231F1E;


### PR DESCRIPTION
## Overview

Hide overflow if `.tab-toggle` is outside of a slide.

_Temp fix until `.texascale-slide` is made responsive._

## Related

- fixes #30

## Changes

- add style `overflow: hidden`

## Testing & UI

1. Open https://texascale.org/testing/2025/people-programs/mentorship-pays-it-forward/.
2. Change viewport width until horizontal scrollbar appears.
3. Apply fix.
4. Verify scrollbar is gone.

## UI

https://github.com/user-attachments/assets/87038cc9-00a0-41a6-a1e2-b11bd8afba75

