### PR TITLE
fix: header not tacc v3 black

### DIFF
--- a/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/1_settings/colors.css
+++ b/cms/src/taccsite_custom/texascale_cms/static/texascale_cms/css/2025/1_settings/colors.css
@@ -6,7 +6,7 @@
 		from var(--tacc-white) srgb r g b / 0.6
 	);
 }
-/* TACC/Core v3 (early) */
+/* TACC/Core v3 (preview) */
 :root {
 	--tacc-blue:  #003049;    /* Prussian Blue */
 	--tacc-white: #FCFDF3;    /* Ivory */
@@ -14,4 +14,8 @@
 	--tacc-orange: #BF5700;   /* Texas Orange */
 	--tacc-beige: #EAE2B7;    /* Vanilla */
 	--tacc-black: #231F1E;    /* Raisin Black */
+}
+/* TACC/Core v2 (stable) */
+:root {
+	--header-bkgd-color: var(--tacc-black);
 }


### PR DESCRIPTION
## Overview

Header background color should be TACC v3 black.

## Related

None

## Changes

- added a style to set a Core-Styles var

## Testing

1. Rebuild.
2. Deploy/Serve.
3. Verify header is black.

## UI

> [!NOTE]
> I edited CSS live, and verified color value changed.

https://github.com/user-attachments/assets/81fda1ac-3312-4d35-a1e8-1a2a47f0c926