### PR TITLE
feat: `.texascale-background`

### DIFF
--- a/cms/Dockerfile
+++ b/cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:v4.36.6
+FROM taccwma/core-cms:80208ac2
 
 WORKDIR /code
 

--- a/cms/src/taccsite_custom/texascale_cms/templates/snippets/2025/2025-css-background.html
+++ b/cms/src/taccsite_custom/texascale_cms/templates/snippets/2025/2025-css-background.html
@@ -1,0 +1,17 @@
+{% load sekizai_tags %}
+{% addtoblock "css" %}
+{# FAQ: `data-design="2025" media="not all"` protects Legacy pages #}
+<style id="2025-css-background" data-design="2025" media="not all">
+.texascale-background {
+    color: var(--texascale-gold);
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0.2;
+}
+/* To render siblings, that follow the background, atop it */
+.texascale-background ~ * {
+  position: relative;
+}
+</style>
+{% endaddtoblock %}


### PR DESCRIPTION
## Overview

- Default styles for hero background icons.
- New CMS image that improves SVG icon a11y.
    <sub>https://github.com/TACC/Core-CMS/pull/997</sub>

## Notes

Instances of each icon set —

- `scale`
- `rotate`

— and override —

- `top`
- `left`