### PR TITLE
feat: custom run-time build id

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,6 @@ Our [production site] is built from a specific commit.
 
 Only appointed team members may release versions.
 
-0. Build CSS
 1. [Create release and tag](https://github.com/TACC/Texascale-CMS/releases/new) `vN.N.N`.
 2. [Build project](https://github.com/TACC/Texascale-CMS/actions/workflows/build.yml) from tag `vN.N.N`.
 

--- a/cms/package.json
+++ b/cms/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "npm run build:css && npm run build:sass",
-    "build:css": "export BUILD_ID=\"$(git describe --tags)\" && ./bin/build-css.js",
+    "build:css": "export BUILD_ID=\"${BUILD_ID:-$(git describe --tags)}\" && ./bin/build-css.js",
     "build:sass": "npx sass --pkg-importer=node --quiet-deps ./src/taccsite_custom/texascale_cms/static/texascale_cms/css/bootstrap/bootstrap-v4.custom.scss ./src/taccsite_custom/texascale_cms/static/texascale_cms/css/bootstrap/bootstrap-v4.custom.css --style compressed",
     "build:dev": "npm run build -- --quiet && npm run collectstatic",
     "collectstatic": "docker-compose exec cms python3 manage.py collectstatic --noinput --verbosity=1 2>&1 | grep -v 'Found another file'",


### PR DESCRIPTION
## Overview

Allow custom run-time `BUILD_ID` for CSS build.

## Changes

- use existing `BUILD_ID` parameter if set
- delete extraneous "Release Workflow" step

## Testing

1. Run `BUILD_ID=dev-123 npm run build:css`.
2. See any `.min.css` file has `dev-123` at top of file.
3. Run `npm run build:css`.
4. See the `.min.css` now has something like `v1.6.0-1-g3a568d93`.

## UI

Skipped.